### PR TITLE
Add support for custom user model

### DIFF
--- a/docs/api/dynamic_stubs/rules.md
+++ b/docs/api/dynamic_stubs/rules.md
@@ -28,6 +28,16 @@
         members:
             - STUB_FILES
 
+::: django_autotyping.stubbing.codemods.auth_functions_codemod.AuthFunctionsCodemod
+    options:
+        show_bases: false
+        show_source: false
+        show_root_heading: true
+        show_root_full_path: false
+        show_if_no_docstring: true
+        members:
+            - STUB_FILES
+
 ::: django_autotyping.stubbing.codemods.reverse_overload_codemod.ReverseOverloadCodemod
     options:
         show_bases: false

--- a/docs/usage/dynamic_stubs.md
+++ b/docs/usage/dynamic_stubs.md
@@ -13,7 +13,8 @@ The following is a list of the available rules related to dynamic stubs:
 - [`DJAS001`][django_autotyping.stubbing.codemods.forward_relation_overload_codemod.ForwardRelationOverloadCodemod]: add overloads to the `__init__` methods of related fields.
 - [`DJAS002`][django_autotyping.stubbing.codemods.create_overload_codemod.CreateOverloadCodemod]: Add overloads to methods creating an instance of a model.
 - [`DJAS010`][django_autotyping.stubbing.codemods.get_model_overload_codemod.GetModelOverloadCodemod]: Add overloads to the [`apps.get_model`][django.apps.apps.get_model] method.
-- [`DJAS011`][django_autotyping.stubbing.codemods.reverse_overload_codemod.ReverseOverloadCodemod]: Add overloads to the [`reverse`][django.urls.reverse] function.
+- [`DJAS011`][django_autotyping.stubbing.codemods.auth_functions_codemod.AuthFunctionsCodemod]: Add a custom return type to the to auth related functions.
+- [`DJAS015`][django_autotyping.stubbing.codemods.reverse_overload_codemod.ReverseOverloadCodemod]: Add overloads to the [`reverse`][django.urls.reverse] function.
 
 
 ## Type checker configuration

--- a/src/django_autotyping/app_settings.py
+++ b/src/django_autotyping/app_settings.py
@@ -94,7 +94,7 @@ class StubsGenerationSettings:
     Moreover, only tuples can be type checked, and most people are using lists for this argument.
     Instead, it is recommended to use the `kwargs` argument.
 
-    Affected rules: `DJAS011`.
+    Affected rules: `DJAS015`.
     """
 
 

--- a/src/django_autotyping/stubbing/codemods/__init__.py
+++ b/src/django_autotyping/stubbing/codemods/__init__.py
@@ -4,6 +4,7 @@ from typing import Container, Literal
 
 from django_autotyping._compat import TypeAlias
 
+from .auth_functions_codemod import AuthFunctionsCodemod
 from .base import StubVisitorBasedCodemod
 from .create_overload_codemod import CreateOverloadCodemod
 from .forward_relation_overload_codemod import ForwardRelationOverloadCodemod
@@ -20,14 +21,15 @@ __all__ = (
     "ReverseOverloadCodemod",
 )
 
-RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011"]
+RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015"]
 
 rules: list[tuple[RulesT, type[StubVisitorBasedCodemod]]] = [
     ("DJAS001", ForwardRelationOverloadCodemod),
     ("DJAS002", CreateOverloadCodemod),
     # ("DJAS003", QueryLookupsOverloadCodemod),
     ("DJAS010", GetModelOverloadCodemod),
-    ("DJAS011", ReverseOverloadCodemod),
+    ("DJAS011", AuthFunctionsCodemod),
+    ("DJAS015", ReverseOverloadCodemod),
 ]
 
 

--- a/src/django_autotyping/stubbing/codemods/auth_functions_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/auth_functions_codemod.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import libcst as cst
+import libcst.matchers as m
+from django.contrib.auth import get_user_model
+from libcst import helpers
+from libcst.codemod import CodemodContext
+from libcst.codemod.visitors import AddImportsVisitor
+
+from .base import StubVisitorBasedCodemod
+from .utils import get_param
+
+# Matchers:
+
+AUTHENTICATE_DEF_MATCHER = m.FunctionDef(name=m.Name("authenticate"))
+"""Matches the `authenticate` function definition."""
+
+LOGIN_DEF_MATCHER = m.FunctionDef(name=m.Name("login"))
+"""Matches the `login` function definition."""
+
+GET_USER_MODEL_DEF_MATCHER = m.FunctionDef(name=m.Name("get_user_model"))
+"""Matches the `get_user_model` function definition."""
+
+GET_USER_DEF_MATCHER = m.FunctionDef(name=m.Name("get_user"))
+"""Matches the `get_user` function definition."""
+
+UPDATE_SESSION_AUTH_HASH_DEF_MATCHER = m.FunctionDef(name=m.Name("update_session_auth_hash"))
+"""Matches the `update_session_auth_hash` function definition."""
+
+
+class AuthFunctionsCodemod(StubVisitorBasedCodemod):
+    """A codemod that will add a custom return type to the to auth related functions.
+
+    The following functions are affected:
+
+    - [`authenticate`][django.contrib.auth.authenticate]
+    - [`login`][django.contrib.auth.login]
+    - [`get_user_model`][django.contrib.auth.get_user_model]
+    - [`get_user`][django.contrib.auth.get_user]
+    - [`update_session_auth_hash`][django.contrib.auth.update_session_auth_hash]
+
+    Rule identifier: `DJAS011`.
+
+    ```python
+    from django.contrib.auth import authenticate, get_user_model, get_user
+
+    reveal_type(authenticate(rq, **creds))  # Revealed type is "YourCustomUser | None"
+    reveal_type(get_user_model())  # Revealed type is "type[YourCustomUser]"
+    reveal_type(get_user(rq))  # Revealed type is "YourCustomUser | AnonymousUser"
+    ```
+    """
+
+    STUB_FILES = {"contrib/auth/__init__.pyi"}
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        user_model = get_user_model()
+        self.user_model_name = user_model.__name__
+
+        AddImportsVisitor.add_needed_import(
+            self.context,
+            module=user_model._meta.app_config.models_module.__name__,
+            obj=self.user_model_name,
+        )
+
+    @m.leave(AUTHENTICATE_DEF_MATCHER)
+    def mutate_AuthenticateFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        return updated_node.with_changes(
+            returns=cst.Annotation(helpers.parse_template_expression(f"{self.user_model_name} | None"))
+        )
+
+    @m.leave(LOGIN_DEF_MATCHER)
+    def mutate_LoginFunctionDef(self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef) -> cst.FunctionDef:
+        user_param = get_param(updated_node, "user")
+        return updated_node.with_deep_changes(
+            user_param, annotation=cst.Annotation(helpers.parse_template_expression(f"{self.user_model_name} | None"))
+        )
+
+    @m.leave(GET_USER_DEF_MATCHER)
+    def mutate_GetUserFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        return updated_node.with_changes(
+            returns=cst.Annotation(helpers.parse_template_expression(f"{self.user_model_name} | AnonymousUser"))
+        )
+
+    @m.leave(GET_USER_MODEL_DEF_MATCHER)
+    def mutate_GetUserModelFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        return updated_node.with_changes(
+            returns=cst.Annotation(helpers.parse_template_expression(f"type[{self.user_model_name}]"))
+        )
+
+    @m.leave(UPDATE_SESSION_AUTH_HASH_DEF_MATCHER)
+    def mutate_UpdateSessionAuthHashFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        user_param = get_param(updated_node, "user")
+        return updated_node.with_deep_changes(
+            user_param, annotation=cst.Annotation(helpers.parse_template_expression(self.user_model_name))
+        )

--- a/src/django_autotyping/stubbing/codemods/get_model_overload_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/get_model_overload_codemod.py
@@ -26,8 +26,8 @@ class GetModelOverloadCodemod(StubVisitorBasedCodemod):
     Rule identifier: `DJAS010`.
 
     ```python
-    reveal_type(apps.get_model("app_name.ModelName"))  # Revealed type is type[ModelName]
-    reveal_type(apps.get_model("app_name", "ModelName"))  # Revealed type is type[ModelName]
+    reveal_type(apps.get_model("app_name.ModelName"))  # Revealed type is "type[ModelName]"
+    reveal_type(apps.get_model("app_name", "ModelName"))  # Revealed type is "type[ModelName]"
     ```
     """
 

--- a/src/django_autotyping/stubbing/codemods/reverse_overload_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/reverse_overload_codemod.py
@@ -46,7 +46,7 @@ REVERSE_DEF_MATCHER = m.FunctionDef(name=m.Name("reverse"))
 class ReverseOverloadCodemod(StubVisitorBasedCodemod):
     """A codemod that will add overloads to the [`reverse`][django.urls.reverse] function.
 
-    **Rule identifier**: `DJAS011`.
+    **Rule identifier**: `DJAS015`.
 
     **Related settings**:
 

--- a/src/django_autotyping/typing.py
+++ b/src/django_autotyping/typing.py
@@ -17,7 +17,7 @@ else:
     FlattenFunctionDef = cst.FunctionDef
 
 
-RulesT: TypeAlias = Literal["DJA001", "DJAS001", "DJAS002", "DJAS010", "DJAS011"]
+RulesT: TypeAlias = Literal["DJA001", "DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015"]
 
 
 class AutotypingSettingsDict(TypedDict, total=False):
@@ -101,7 +101,7 @@ class StubsGenerationSettingsDict(TypedDict, total=False):
     Moreover, only tuples can be type checked, and most people are using lists for this argument.
     Instead, it is recommended to use the `kwargs` argument.
 
-    Affected rules: `DJAS011`.
+    Affected rules: `DJAS015`.
     """
 
 

--- a/tests/stubbing/test_stubs.py
+++ b/tests/stubbing/test_stubs.py
@@ -24,6 +24,7 @@ testfiles_params = pytest.mark.parametrize(
         ("djas001_no_plain_references.py", ["DJAS001"], StubsGenerationSettings(ALLOW_PLAIN_MODEL_REFERENCES=False)),
         ("djas001_allow_non_set_type.py", ["DJAS001"], StubsGenerationSettings(ALLOW_NONE_SET_TYPE=True)),
         ("djas010.py", ["DJAS010"], StubsGenerationSettings()),
+        ("djas011.py", ["DJAS011"], StubsGenerationSettings()),
     ],
 )
 # fmt: on
@@ -80,7 +81,13 @@ def test_pyright(
 
     config_file = tmp_path / "pyrightconfig.json"
     config_file.write_text(
-        json.dumps({"stubPath": str(local_stubs.absolute()), "extraPaths": [str(STUBSTESTPROJ.parent)]})
+        json.dumps(
+            {
+                "stubPath": str(local_stubs.absolute()),
+                "extraPaths": [str(STUBSTESTPROJ.parent)],
+                "reportUnnecessaryTypeIgnoreComment": True,
+            }
+        )
     )
 
     exit_code = run_pyright(["--project", str(config_file), str(testfile)])

--- a/tests/stubbing/testfiles/djas011.py
+++ b/tests/stubbing/testfiles/djas011.py
@@ -1,0 +1,17 @@
+from typing_extensions import assert_type
+
+from django.contrib.auth import authenticate, login, get_user_model, get_user, update_session_auth_hash
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.http.request import HttpRequest
+
+from stubstestproj.accounts.models import User
+
+req = HttpRequest()
+abstract_user = AbstractBaseUser()
+
+assert_type(authenticate(req), User | None)
+assert_type(get_user_model(), type[User])
+assert_type(get_user(req), User | AnonymousUser)
+
+login(req, abstract_user)  # type: ignore
+update_session_auth_hash(req, abstract_user)  # type: ignore

--- a/tests/stubstestproj/accounts/models.py
+++ b/tests/stubstestproj/accounts/models.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.models import AbstractBaseUser
+
+
+class User(AbstractBaseUser):
+    pass

--- a/tests/stubstestproj/settings.py
+++ b/tests/stubstestproj/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "stubstestproj.accounts",
     "stubstestproj.firstapp",
     "stubstestproj.secondapp",
 ]
@@ -70,3 +71,6 @@ DATABASES = {
         "NAME": BASE_DIR / "db.sqlite3",
     }
 }
+
+# For DJAS011
+AUTH_USER_MODEL = "accounts.User"


### PR DESCRIPTION
Closes #16.

Looking at the current `django-stubs`, there are probably many places where this could be applied. However, we'll have to see if they are relevant