### PR TITLE
Add draft implementation for `call_command` overloads

### DIFF
--- a/src/django_autotyping/_compat.py
+++ b/src/django_autotyping/_compat.py
@@ -2,9 +2,9 @@ import sys
 from pathlib import Path
 
 if sys.version_info >= (3, 11):
-    from typing import NotRequired, Required, Self, TypeAlias, Unpack
+    from typing import NotRequired, Required, Self, TypeAlias, TypeGuard, Unpack
 else:
-    from typing_extensions import NotRequired, Required, Self, TypeAlias, Unpack  # noqa: F401
+    from typing_extensions import NotRequired, Required, Self, TypeAlias, TypeGuard, Unpack  # noqa: F401
 
 if sys.version_info >= (3, 10):
     from types import NoneType

--- a/src/django_autotyping/stubbing/codemods/__init__.py
+++ b/src/django_autotyping/stubbing/codemods/__init__.py
@@ -29,7 +29,7 @@ __all__ = (
     "gather_codemods",
 )
 
-RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015", "DJAS016", "DJAS017"]
+RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015", "DJAS016"]
 
 rules: list[tuple[RulesT, type[StubVisitorBasedCodemod]]] = [
     ("DJAS001", ForwardRelationOverloadCodemod),
@@ -39,12 +39,12 @@ rules: list[tuple[RulesT, type[StubVisitorBasedCodemod]]] = [
     ("DJAS011", AuthFunctionsCodemod),
     ("DJAS015", ReverseOverloadCodemod),
     ("DJAS016", SettingCodemod),
-    ("DJAS017", CallCommandCodemod),
+    # ("DJAS017", CallCommandCodemod),
 ]
 
 
 def gather_codemods(
-    ignore: Container[RulesT] = [], include: Container[RulesT] = ["DJAS017"]
+    ignore: Container[RulesT] = [], include: Container[RulesT] = []
 ) -> list[type[StubVisitorBasedCodemod]]:
     if include:
         return [rule[1] for rule in rules if rule[0] in include]

--- a/src/django_autotyping/stubbing/codemods/__init__.py
+++ b/src/django_autotyping/stubbing/codemods/__init__.py
@@ -6,6 +6,7 @@ from django_autotyping._compat import TypeAlias
 
 from .auth_functions_codemod import AuthFunctionsCodemod
 from .base import StubVisitorBasedCodemod
+from .call_command_codemod import CallCommandCodemod
 from .create_overload_codemod import CreateOverloadCodemod
 from .forward_relation_overload_codemod import ForwardRelationOverloadCodemod
 from .get_model_overload_codemod import GetModelOverloadCodemod
@@ -14,15 +15,21 @@ from .reverse_overload_codemod import ReverseOverloadCodemod
 from .settings_codemod import SettingCodemod
 
 __all__ = (
+    "AuthFunctionsCodemod",
     "StubVisitorBasedCodemod",
+    "CallCommandCodemod",
     "CreateOverloadCodemod",
     "ForwardRelationOverloadCodemod",
     "GetModelOverloadCodemod",
     "QueryLookupsOverloadCodemod",
     "ReverseOverloadCodemod",
+    "SettingCodemod",
+    "RulesT",
+    "rules",
+    "gather_codemods",
 )
 
-RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015", "DJAS016"]
+RulesT: TypeAlias = Literal["DJAS001", "DJAS002", "DJAS010", "DJAS011", "DJAS015", "DJAS016", "DJAS017"]
 
 rules: list[tuple[RulesT, type[StubVisitorBasedCodemod]]] = [
     ("DJAS001", ForwardRelationOverloadCodemod),
@@ -32,11 +39,12 @@ rules: list[tuple[RulesT, type[StubVisitorBasedCodemod]]] = [
     ("DJAS011", AuthFunctionsCodemod),
     ("DJAS015", ReverseOverloadCodemod),
     ("DJAS016", SettingCodemod),
+    ("DJAS017", CallCommandCodemod),
 ]
 
 
 def gather_codemods(
-    ignore: Container[RulesT] = [], include: Container[RulesT] = []
+    ignore: Container[RulesT] = [], include: Container[RulesT] = ["DJAS017"]
 ) -> list[type[StubVisitorBasedCodemod]]:
     if include:
         return [rule[1] for rule in rules if rule[0] in include]

--- a/src/django_autotyping/stubbing/codemods/_utils.py
+++ b/src/django_autotyping/stubbing/codemods/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import keyword
 import re
 from dataclasses import dataclass
 
@@ -85,7 +86,7 @@ def build_typed_dict(
         leadind_line: Whether an empty leading line should be added before the class definition.
 
     """
-    functional = any(not attr.name.isidentifier() for attr in attributes)
+    functional = any(keyword.iskeyword(attr.name) for attr in attributes)
     leading_lines = [cst.EmptyLine(indent=False)] if leading_line else []
     if not functional:
         body: list[cst.SimpleStatementLine] = []
@@ -130,7 +131,8 @@ def build_typed_dict(
                             cst.Dict(
                                 elements=[
                                     cst.DictElement(
-                                        key=cst.SimpleString(f'"{attr.name}"'), value=cst.Name(attr.marked_annotation)
+                                        key=cst.SimpleString(f'"{attr.name}"'),
+                                        value=helpers.parse_template_expression(attr.marked_annotation),
                                     )
                                     for attr in attributes
                                 ]

--- a/src/django_autotyping/stubbing/codemods/call_command_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/call_command_codemod.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import libcst as cst
+import libcst.matchers as m
+from libcst import helpers
+from libcst.codemod import CodemodContext
+
+from django_autotyping.typing import FlattenFunctionDef
+
+from ._utils import TypedDictAttribute, build_typed_dict, get_param, to_pascal
+from .base import InsertAfterImportsVisitor, StubVisitorBasedCodemod
+from .constants import OVERLOAD_DECORATOR
+
+# Matchers:
+
+CALL_COMMAND_DEF_MATCHER = m.FunctionDef(name=m.Name("call_command"))
+"""Matches the `call_command` function definition."""
+
+
+class CallCommandCodemod(StubVisitorBasedCodemod):
+    """A codemod that will add overloads for [`call_command`][django.core.management.call_command].
+
+    Rule identifier: `DJAS017`.
+
+    ```python
+    from django.core.management import call_command
+
+    call_command("non_existing_cmd")  # Type error
+    call_command("cmd", non_existing_arg="foo")  # Type error
+    ```
+
+    !!! info "Limited support"
+        TBD
+    """
+
+    STUB_FILES = {"core/management/__init__.pyi"}
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self.add_typing_imports(["Literal", "Required", "TextIO", "TypedDict", "Unpack", "overload"])
+
+    @m.leave(CALL_COMMAND_DEF_MATCHER)
+    def mutate_CallCommandFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> FlattenFunctionDef:
+        overload = updated_node.with_changes(decorators=[OVERLOAD_DECORATOR])
+        overloads: list[cst.FunctionDef] = []
+
+        for command_name, command_info in self.django_context.management_commands_info.items():
+            arg_info_list, options_info = command_info.actions_list[0]
+            overload_ = overload.with_deep_changes(
+                old_node=get_param(overload, "command_name"),
+                annotation=cst.Annotation(helpers.parse_template_expression(f'Literal["{command_name}"]')),
+            )
+            if not arg_info_list:
+                # No positional arguments, signature will be:
+                # `call_command("cmd", **kwargs: Unpack[...])`
+                overload_ = overload_.with_deep_changes(
+                    old_node=overload_.params,
+                    star_arg=cst.MaybeSentinel.DEFAULT,
+                )
+
+            # Build the kwargs annotation, with an unpacked TypedDict
+            typed_dict_name = to_pascal(f"{command_name}") + "Options"
+            options_typed_dict = build_typed_dict(
+                name=typed_dict_name,
+                attributes=[
+                    TypedDictAttribute(
+                        name=option_name,
+                        annotation=option_info.type,
+                        docstring=option_info.help,
+                        required=option_info.required,
+                    )
+                    for option_name, option_info in options_info.items()
+                ],
+                leading_line=True,
+                total=False,
+            )
+            InsertAfterImportsVisitor.insert_after_imports(self.context, [options_typed_dict])
+
+            overload_ = overload_.with_deep_changes(
+                old_node=overload_.params.star_kwarg,
+                annotation=cst.Annotation(helpers.parse_template_expression(f"Unpack[{typed_dict_name}]")),
+            )
+
+            overloads.append(overload_)
+
+        fallback_overload = overload.with_deep_changes(
+            old_node=get_param(overload, "command_name"), annotation=cst.Annotation(cst.Name("BaseCommand"))
+        )
+
+        return cst.FlattenSentinel(overloads + [fallback_overload])
+
+    def _mutate_CallCommandFunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> FlattenFunctionDef:
+        overload = updated_node.with_changes(decorators=[OVERLOAD_DECORATOR])
+        overloads: list[cst.FunctionDef] = []
+
+        for command_name, command_info in self.django_context.management_commands_info.items():
+            for i, (arg_info_list, options_info) in enumerate(command_info.actions_list, start=1):
+                overload_ = overload.with_deep_changes(
+                    old_node=get_param(overload, "command_name"),
+                    annotation=cst.Annotation(helpers.parse_template_expression(f'Literal["{command_name}"]')),
+                )
+
+                if not arg_info_list:
+                    # No positional arguments, signature will be:
+                    # `call_command("cmd", **kwargs: Unpack[...])`
+                    overload_ = overload_.with_deep_changes(
+                        old_node=overload_.params,
+                        star_arg=cst.MaybeSentinel.DEFAULT,
+                    )
+                elif command_info.use_star_args(arg_info_list):
+                    args_annotation = f"*tuple[{', '.join(a.type for a in arg_info_list)}]"
+                    overload_ = overload_.with_deep_changes(
+                        old_node=overload_.params.star_arg,
+                        annotation=cst.Annotation(helpers.parse_template_expression(args_annotation)),
+                    )
+                else:
+                    # Fixed number of positional arguments, signature will be:
+                    # `call_command("cmd", arg1: str, arg2: str, /, **kwargs: Unpack[...])`
+                    parameters = overload_.params
+
+                    # We move `command_name` to be pos only
+                    posonly_params = [get_param(overload_, "command_name")]
+
+                    for arg_info in arg_info_list:
+                        if arg_info.nargs in (1, None):
+                            posonly_params.append(
+                                cst.Param(
+                                    name=cst.Name(
+                                        arg_info.dest or "tbd"
+                                    ),  # "or" fallback if this is a subparser without `dest`
+                                    # `arg_info.type` can safely be used here
+                                    annotation=cst.Annotation(helpers.parse_template_expression(arg_info.type)),
+                                )
+                            )
+                        else:
+                            # only possible case is `nargs>=2`
+                            for i in range(arg_info.nargs):
+                                posonly_params.append(
+                                    cst.Param(
+                                        name=cst.Name(f"{arg_info.dest}_{i}"),
+                                        annotation=cst.Annotation(cst.Name("str")),
+                                    )
+                                )
+
+                    parameters = parameters.with_changes(
+                        star_arg=cst.MaybeSentinel.DEFAULT,
+                        params=[],
+                        posonly_params=posonly_params,
+                    )
+
+                    overload_ = overload_.with_changes(
+                        params=parameters,
+                    )
+
+                # Build the kwargs annotation, with an unpacked TypedDict
+                typed_dict_name = to_pascal(f"{command_name}_options{i if len(command_info.actions_list) >= 2 else ''}")  # noqa: PLR2004
+                options_typed_dict = build_typed_dict(
+                    name=typed_dict_name,
+                    attributes=[
+                        TypedDictAttribute(
+                            name=option_name,
+                            annotation=option_info.type,
+                            docstring=option_info.help,
+                            required=option_info.required,
+                        )
+                        for option_name, option_info in options_info.items()
+                    ],
+                    leading_line=True,
+                    total=False,
+                )
+                InsertAfterImportsVisitor.insert_after_imports(self.context, [options_typed_dict])
+
+                overload_ = overload_.with_deep_changes(
+                    old_node=overload_.params.star_kwarg,
+                    annotation=cst.Annotation(helpers.parse_template_expression(f"Unpack[{typed_dict_name}]")),
+                )
+
+                overloads.append(overload_)
+
+        fallback_overload = overload.with_deep_changes(
+            old_node=get_param(overload, "command_name"), annotation=cst.Annotation(cst.Name("BaseCommand"))
+        )
+
+        return cst.FlattenSentinel(overloads + [fallback_overload])

--- a/src/django_autotyping/stubbing/codemods/call_command_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/call_command_codemod.py
@@ -31,6 +31,7 @@ class CallCommandCodemod(StubVisitorBasedCodemod):
 
     !!! info "Limited support"
         TBD
+        https://github.com/microsoft/pylance-release/discussions/4148
     """
 
     STUB_FILES = {"core/management/__init__.pyi"}

--- a/src/django_autotyping/stubbing/codemods/reverse_overload_codemod.py
+++ b/src/django_autotyping/stubbing/codemods/reverse_overload_codemod.py
@@ -15,7 +15,7 @@ from .base import InsertAfterImportsVisitor, StubVisitorBasedCodemod
 from .constants import OVERLOAD_DECORATOR
 
 if TYPE_CHECKING:
-    from ..django_context import PathInfo
+    from ..django_context._url_utils import PathInfo
 
 # `SupportsStr` is a Protocol that supports `__str__`.
 # This should be equivalent to `object`, but is used to be

--- a/src/django_autotyping/stubbing/django_context/__init__.py
+++ b/src/django_autotyping/stubbing/django_context/__init__.py
@@ -1,0 +1,3 @@
+from .django_context import DjangoStubbingContext
+
+__all__ = ("DjangoStubbingContext",)

--- a/src/django_autotyping/stubbing/django_context/_management_utils.py
+++ b/src/django_autotyping/stubbing/django_context/_management_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from argparse import (
     ONE_OR_MORE,
+    SUPPRESS,
     ZERO_OR_MORE,
     Action,
     _AppendAction,
@@ -18,7 +19,7 @@ from argparse import (
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Iterator, cast
+from typing import Any, Iterator, Literal, cast
 
 from django.core.management import BaseCommand, get_commands, load_command_class
 from django.core.management.base import CommandParser
@@ -42,110 +43,248 @@ TYPE_MAP = {
 }
 
 
-def get_actions(parser: CommandParser) -> Iterator[Action]:
-    # Parser actions and actions from sub-parser choices.
-    for opt in parser._actions:
-        if isinstance(opt, _SubParsersAction):
-            yield opt
-            for sub_opt in opt.choices.values():
-                yield from get_actions(sub_opt)
-        else:
-            yield opt
+def get_commands_infos(commands: dict[str, str] | None = None) -> dict[str, CommandInfo]:
+    """Returns a mapping of command names to a `CommandInfo` instance."""
 
-
-def get_commands_info(commands: dict[str, str] | None = None):
-    # Code is inspired from the actual `call_command` function implementation
+    commands_infos: dict[str, CommandInfo] = {}
     commands = commands or get_commands()
+
     for command_name, app_name in commands.items():
         app_name = cast(BaseCommand | str, app_name)  # `django-stubs` is probably wrong
         if isinstance(app_name, BaseCommand):
             command = app_name
         else:
-            command = load_command_class(app_name, command_name)
-
+            try:
+                command = load_command_class(app_name, command_name)
+            except Exception:
+                # Commands might fail on import
+                continue
         parser = command.create_parser("", command_name)
 
-        # 1. Deal with "top level" actions. These will always be present in the signature(s),
-        # even if subparsers are involved.
+        # 1. Deal with "stealth" actions. These will always be present in the signature(s).
 
-        top_level_options: dict[str, OptionInfo] = {}
-
-        # 1.1. Stealth options
+        top_level_options_infos: dict[str, OptionInfo] = {}
 
         stealth_options = set(command.base_stealth_options + command.stealth_options)
 
         for option in stealth_options:
-            option_info = OptionInfo()
+            option_info = OptionInfo(required=False)
             if option in {"stdout", "stderr"}:
                 option_info.typing_imports.append("TextIO")
                 option_info.type = "TextIO"
+
             # For the other stealth options, the default type (`Any`) is kept.
+            top_level_options_infos[option] = option_info
 
-            top_level_options[option] = option_info
+        # 2. Build a list of two-tuples:
+        # - The first element is a list of `ArgInfo` instances, will be used for the `*args` annotation
+        # - The second element is a dict of `OptionInfo` instances, will be used for the `*kwargs` annotation
+        # Most of the time, this list will only contain one tuple, which represents the actual signature
+        # for this command. If subparsers are involved, the list will contain multiple elements and will map
+        # to an overload.
 
-        # 1.2. `_AppendConstAction`/`_AppendAction` are handled separately. If more that two of them
-        # points to the same dest, only `dest` is used as a possible argument, as it could otherwise
-        # lead to some errors: if two actions `--foo` and `--bar` append to dest `baz`, calling
-        # "--foo 1 --bar 2" will result in "baz=['1', '2']".
-        # However, `call_command(foo='1', bar='2')` will result in "baz='2'".
+        actions_list = list(
+            _iter_actions(
+                parser,
+                is_subparser=False,
+                parent_args=[],
+                parent_options=top_level_options_infos,
+            )
+        )
 
-        append_actions_list = [
-            action
-            for action in parser._get_optional_actions()
-            if isinstance(action, (_AppendConstAction, _AppendAction))
-        ]
+        commands_infos[command_name] = CommandInfo(actions_list)
 
-        append_const_actions: defaultdict[str, list[_AppendConstAction]] = defaultdict(list)
-        append_actions: defaultdict[str, list[_AppendAction]] = defaultdict(list)
+    return commands_infos
 
-        for action in append_actions_list:
-            if isinstance(action, _AppendConstAction):
-                append_const_actions[action.dest].append(action)
-            if isinstance(action, _AppendAction):
-                append_actions[action.dest].append(action)
 
-        for actions_dict in (append_const_actions, append_actions):
-            for dest, action_list in actions_dict.items():
-                if actions_dict is append_const_actions:
-                    option_info = OptionInfo.from_append_const_actions(*action_list)
-                else:
-                    option_info = OptionInfo.from_append_actions(*action_list)
+def _iter_actions(
+    parser: CommandParser, is_subparser: bool, parent_args: list[ArgInfo], parent_options: dict[str, OptionInfo]
+) -> Iterator[tuple[list[ArgInfo], dict[str, OptionInfo]]]:
+    pos_actions = [action for action in parser._get_positional_actions() if not isinstance(action, _SubParsersAction)]
 
-                if len(action_list) >= 2:  # noqa: PLR2004
-                    # We only accept the `dest` value as an argument to `call_command`
-                    top_level_options[dest] = option_info
-                else:
+    arg_infos = parent_args + [ArgInfo(nargs=action.nargs, dest=action.dest) for action in pos_actions]
+    options = {**parent_options, **get_options_infos(parser, is_subparser=is_subparser)}
+
+    yield arg_infos, options
+
+    subparsers_actions = [
+        action for action in parser._get_positional_actions() if isinstance(action, _SubParsersAction)
+    ]
+    assert len(subparsers_actions) <= 1  # Only one `add_subparsers` call is allowed
+
+    if subparsers_actions:
+        subparser_action = subparsers_actions[0]
+        for act in subparser_action._get_subactions():
+            yield from _iter_actions(
+                parser=subparser_action.choices[act.dest],
+                is_subparser=True,
+                parent_args=arg_infos
+                + [
+                    ArgInfo(
+                        nargs=None,
+                        dest=subparser_action.dest if subparser_action.dest != SUPPRESS else None,
+                        subparser_arg=act.dest,
+                    )
+                ],
+                parent_options=options,
+            )
+
+
+def get_options_infos(parser: CommandParser, is_subparser: bool = False) -> dict[str, OptionInfo]:
+    """Returns a mapping between the option names and `OptionInfo` instances.
+
+    Depending on the action type, the type annotation will be adapted accordingly. For example,
+    `append` actions will require the type annotation to be a list.
+
+    If `is_subparser` is set, only the `dest` value will be used as an option name. This comes
+    from the fact that the `call_command` somehow treats subparsers differently. For "top level"
+    options, the option name (i.e. `--opt`) and `dest` will be available (if different).
+    """
+
+    # 1. `_AppendConstAction`/`_AppendAction` are handled separately. If more that two of them
+    # points to the same dest, only `dest` is used as a possible argument, as it could otherwise
+    # lead to some errors: if two actions `--foo` and `--bar` append to `dest` "baz", calling
+    # "--foo 1 --bar 2" will result in "baz=['1', '2']".
+    # However, `call_command(foo='1', bar='2')` will result in "baz='2'".
+    # For subparsers, `call_command` only allows using `dest` anyway.
+
+    options_dict: dict[str, OptionInfo] = {}
+
+    append_actions_list = [
+        action for action in parser._get_optional_actions() if isinstance(action, (_AppendConstAction, _AppendAction))
+    ]
+
+    append_const_actions: defaultdict[str, list[_AppendConstAction]] = defaultdict(list)
+    append_actions: defaultdict[str, list[_AppendAction]] = defaultdict(list)
+
+    for action in append_actions_list:
+        if isinstance(action, _AppendConstAction):
+            append_const_actions[action.dest].append(action)
+        if isinstance(action, _AppendAction):
+            append_actions[action.dest].append(action)
+
+    for actions_dict in (append_const_actions, append_actions):
+        for dest, action_list in actions_dict.items():
+            if actions_dict is append_const_actions:
+                option_info = OptionInfo.from_append_const_actions(*action_list)
+            else:
+                option_info = OptionInfo.from_append_actions(*action_list)
+
+            if len(action_list) >= 2:  # noqa: PLR2004
+                # We only accept the `dest` value as an argument to `call_command`
+                # even if it is the parser is the main one.
+                options_dict[dest] = option_info
+            else:
+                if not is_subparser:
                     action_name = min(action.option_strings).lstrip("-").replace("-", "_")
-                    top_level_options[action_name] = option_info
+                    options_dict[action_name] = option_info
 
-                    if dest != action_name:
-                        top_level_options[dest] = deepcopy(option_info)
+                if dest != action_name or is_subparser:
+                    options_dict[dest] = deepcopy(option_info)
 
-        # 1.3. Remaining actions
+    # 2. Remaining actions
 
-        top_level_optional_actions = [
-            action
-            for action in parser._get_optional_actions()
-            if not isinstance(action, (_HelpAction, _VersionAction, _AppendConstAction, _AppendAction))
-        ]
+    remaining_actions = [
+        action
+        for action in parser._get_optional_actions()
+        if not isinstance(action, (_HelpAction, _VersionAction, _AppendConstAction, _AppendAction))
+    ]
 
-        for action in top_level_optional_actions:
-            action_name = min(action.option_strings).lstrip("-").replace("-", "_")
+    for action in remaining_actions:
+        action_name = min(action.option_strings).lstrip("-").replace("-", "_")
 
-            option_info = OptionInfo.from_action(action)
+        option_info = OptionInfo.from_action(action)
 
-            top_level_options[action_name] = option_info
+        if not is_subparser:
+            options_dict[action_name] = option_info
 
-            if action.dest != action_name:
-                # Django allows both arguments, but only for top level options (not subparsers)
-                top_level_options[action.dest] = deepcopy(option_info)
+        if action.dest != action_name or is_subparser:
+            # Django allows both arguments, but only for top level options (for subparsers, only `dest`)
+            options_dict[action.dest] = deepcopy(option_info)
+
+    return options_dict
+
+
+@dataclass
+class CommandInfo:
+    actions_list: list[tuple[list[ArgInfo], dict[str, OptionInfo]]]
+
+    @staticmethod
+    def use_star_args(arg_info_list: list[ArgInfo]) -> bool:
+        """Whether `*args` should be used to annotate the positional arguments.
+
+        This is the case for instance when an arbitrary number of arguments can be provided.
+        """
+        return any(arg_info.nargs in {"*", "+", "?"} for arg_info in arg_info_list)
+
+
+@dataclass
+class ArgInfo:
+    nargs: Literal["*", "+", "?"] | int | None
+    """The `nargs` argument of the action.
+
+    A value of `None` has two meanings, depending on the value of `subparser_arg`.
+    """
+
+    dest: str | None = None
+    """The `dest` argument of the action.
+
+    Can take the value of `None` only if `suparser_arg` is set.
+    """
+
+    subparser_arg: str | None = None
+    """If set, this `ArgInfo` instance represents a subparser action."""
+
+    def __post_init__(self) -> None:
+        if self.subparser_arg and self.nargs is not None:
+            raise ValueError("A subparser argument cannot have nargs.")
+        if not self.subparser_arg and self.dest is None:
+            raise ValueError("dest cannot be None if this is not a subparser argument.")
+
+    @property
+    def type(self) -> str:
+        """The type annotation to be used as part of the `*args` annotation.
+
+        This is only relevant when building a more precise type for heterogeneous `*args`,
+        as defined in PEP 646.
+
+        Having a list of `ArgInfo` instances, the final annotation can be built this way:
+
+        ```python
+        arg_info_list: list[ArgInfo]
+        args_annotation = f"*tuple[{', '.join(arg_info.star_args_type) for arg_info in arg_info_list}]"
+
+        # Which would result in the following signature:
+        def func(*args: *tuple[str, *tuple[str, ...], Literal["subcmd"]]): ...
+        ```
+        """
+        if self.nargs is None:
+            if self.subparser_arg:
+                return f"Literal[{self.subparser_arg}]"
+            return "str"
+        if isinstance(self.nargs, int):
+            return ", ".join("str" for _ in range(self.nargs))
+        if self.nargs == "+":
+            return "str, *tuple[str, ...]"
+        if self.nargs in ["*", "?"]:  # TODO actual support for "?", ideally should generate overloads
+            return "*tuple[str, ...]"
 
 
 @dataclass
 class OptionInfo:
+    """A class holding information regarding a specific (optional) command option."""
+
     required: bool
+    """Whether the option is required."""
+
     typing_imports: list[str] = field(default_factory=list)
+    """A list of typing objects to be imported."""
+
     type: str = "Any"
+    """The string representation of the option type."""
+
+    help: str | None = None
+    """The help text of the option."""
 
     @staticmethod
     def _get_type(action_type: Any) -> str:
@@ -188,7 +327,7 @@ class OptionInfo:
             if isinstance(action.nargs, int) or action.nargs in [ZERO_OR_MORE, ONE_OR_MORE]:
                 type = f"list[{type}]"
 
-        return cls(typing_imports=typing_imports, type=type, required=action.required)
+        return cls(typing_imports=typing_imports, type=type, required=action.required, help=action.help)
 
     @classmethod
     def from_append_const_actions(cls, *actions: _AppendConstAction) -> Self:
@@ -213,7 +352,7 @@ class OptionInfo:
 
         type = f"list[{' | '.join(types)}]"
 
-        return cls(typin_imports=typing_imports, type=type, required=any(action.required for action in actions))
+        return cls(typing_imports=typing_imports, type=type, required=any(action.required for action in actions))
 
 
 def _is_literal(const: Any) -> TypeGuard[str | bytes | int | bool | None]:

--- a/src/django_autotyping/stubbing/django_context/_management_utils.py
+++ b/src/django_autotyping/stubbing/django_context/_management_utils.py
@@ -105,6 +105,7 @@ def _iter_actions(
     arg_infos = parent_args + [ArgInfo(nargs=action.nargs, dest=action.dest) for action in pos_actions]
     options = {**parent_options, **get_options_infos(parser, is_subparser=is_subparser)}
 
+    # TODO shouldn't yield if subparsers are required
     yield arg_infos, options
 
     subparsers_actions = [

--- a/src/django_autotyping/stubbing/django_context/_management_utils.py
+++ b/src/django_autotyping/stubbing/django_context/_management_utils.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import sys
+from argparse import (
+    ONE_OR_MORE,
+    ZERO_OR_MORE,
+    Action,
+    _AppendAction,
+    _AppendConstAction,
+    _CountAction,
+    _HelpAction,
+    _StoreConstAction,
+    _StoreFalseAction,
+    _StoreTrueAction,
+    _SubParsersAction,
+    _VersionAction,
+)
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Iterator, cast
+
+from django.core.management import BaseCommand, get_commands, load_command_class
+from django.core.management.base import CommandParser
+
+from django_autotyping._compat import NoneType, Self, TypeGuard
+
+BOOL_ACTIONS: tuple[type[Action], ...] = (
+    _StoreTrueAction,
+    _StoreFalseAction,
+)
+
+if sys.version_info >= (3, 9):
+    from argparse import BooleanOptionalAction
+
+    BOOL_ACTIONS += (BooleanOptionalAction,)
+
+TYPE_MAP = {
+    "str": str,
+    "int": int,
+    "float": float,
+}
+
+
+def get_actions(parser: CommandParser) -> Iterator[Action]:
+    # Parser actions and actions from sub-parser choices.
+    for opt in parser._actions:
+        if isinstance(opt, _SubParsersAction):
+            yield opt
+            for sub_opt in opt.choices.values():
+                yield from get_actions(sub_opt)
+        else:
+            yield opt
+
+
+def get_commands_info(commands: dict[str, str] | None = None):
+    # Code is inspired from the actual `call_command` function implementation
+    commands = commands or get_commands()
+    for command_name, app_name in commands.items():
+        app_name = cast(BaseCommand | str, app_name)  # `django-stubs` is probably wrong
+        if isinstance(app_name, BaseCommand):
+            command = app_name
+        else:
+            command = load_command_class(app_name, command_name)
+
+        parser = command.create_parser("", command_name)
+
+        # 1. Deal with "top level" actions. These will always be present in the signature(s),
+        # even if subparsers are involved.
+
+        top_level_options: dict[str, OptionInfo] = {}
+
+        # 1.1. Stealth options
+
+        stealth_options = set(command.base_stealth_options + command.stealth_options)
+
+        for option in stealth_options:
+            option_info = OptionInfo()
+            if option in {"stdout", "stderr"}:
+                option_info.typing_imports.append("TextIO")
+                option_info.type = "TextIO"
+            # For the other stealth options, the default type (`Any`) is kept.
+
+            top_level_options[option] = option_info
+
+        # 1.2. `_AppendConstAction`/`_AppendAction` are handled separately. If more that two of them
+        # points to the same dest, only `dest` is used as a possible argument, as it could otherwise
+        # lead to some errors: if two actions `--foo` and `--bar` append to dest `baz`, calling
+        # "--foo 1 --bar 2" will result in "baz=['1', '2']".
+        # However, `call_command(foo='1', bar='2')` will result in "baz='2'".
+
+        append_actions_list = [
+            action
+            for action in parser._get_optional_actions()
+            if isinstance(action, (_AppendConstAction, _AppendAction))
+        ]
+
+        append_const_actions: defaultdict[str, list[_AppendConstAction]] = defaultdict(list)
+        append_actions: defaultdict[str, list[_AppendAction]] = defaultdict(list)
+
+        for action in append_actions_list:
+            if isinstance(action, _AppendConstAction):
+                append_const_actions[action.dest].append(action)
+            if isinstance(action, _AppendAction):
+                append_actions[action.dest].append(action)
+
+        for actions_dict in (append_const_actions, append_actions):
+            for dest, action_list in actions_dict.items():
+                if actions_dict is append_const_actions:
+                    option_info = OptionInfo.from_append_const_actions(*action_list)
+                else:
+                    option_info = OptionInfo.from_append_actions(*action_list)
+
+                if len(action_list) >= 2:  # noqa: PLR2004
+                    # We only accept the `dest` value as an argument to `call_command`
+                    top_level_options[dest] = option_info
+                else:
+                    action_name = min(action.option_strings).lstrip("-").replace("-", "_")
+                    top_level_options[action_name] = option_info
+
+                    if dest != action_name:
+                        top_level_options[dest] = deepcopy(option_info)
+
+        # 1.3. Remaining actions
+
+        top_level_optional_actions = [
+            action
+            for action in parser._get_optional_actions()
+            if not isinstance(action, (_HelpAction, _VersionAction, _AppendConstAction, _AppendAction))
+        ]
+
+        for action in top_level_optional_actions:
+            action_name = min(action.option_strings).lstrip("-").replace("-", "_")
+
+            option_info = OptionInfo.from_action(action)
+
+            top_level_options[action_name] = option_info
+
+            if action.dest != action_name:
+                # Django allows both arguments, but only for top level options (not subparsers)
+                top_level_options[action.dest] = deepcopy(option_info)
+
+
+@dataclass
+class OptionInfo:
+    required: bool
+    typing_imports: list[str] = field(default_factory=list)
+    type: str = "Any"
+
+    @staticmethod
+    def _get_type(action_type: Any) -> str:
+        # TODO Support more types
+        if action_type is None:
+            return "str"
+        if action_type in TYPE_MAP:
+            return TYPE_MAP[action_type]
+        return "Any"
+
+    @classmethod
+    def from_action(cls, action: Action) -> Self:
+        typing_imports: list[str] = []
+
+        if isinstance(action, _CountAction):
+            type = "int"
+        elif isinstance(action, BOOL_ACTIONS):
+            # These actions do not have `nargs`/`type`
+            # `BooleanOptionalAction` has a `type` arg but seems to be unused.
+            type = "bool"
+        elif isinstance(action, _StoreConstAction):
+            # These actions do not have `nargs`/`type`
+            # Type needs to be the type of `const`
+
+            # First, try to represent it as a `Literal`:
+            if _is_literal(action.const):
+                typing_imports.append("Literal")
+                type = f"Literal[{action.const!r}]"
+            else:
+                # Else, fallback to `Any` for now
+                # TODO Support other `const` types, more work required as things should be imported
+                typing_imports.append("Any")
+                type = "Any"
+        else:
+            # TODO what to do with extend action?
+            type = cls._get_type(action.type)
+            if type == "Any":
+                typing_imports.append("Any")
+
+            if isinstance(action.nargs, int) or action.nargs in [ZERO_OR_MORE, ONE_OR_MORE]:
+                type = f"list[{type}]"
+
+        return cls(typing_imports=typing_imports, type=type, required=action.required)
+
+    @classmethod
+    def from_append_const_actions(cls, *actions: _AppendConstAction) -> Self:
+        typing_imports: list[str] = []
+
+        if all(_is_literal(action.const) for action in actions):
+            typing_imports.append("Literal")
+            type = f"list[Literal[{', '.join(repr(action.const) for action in actions)}]]"
+        else:
+            typing_imports.append("Any")
+            type = "list[Any]"
+
+        return cls(typing_imports=typing_imports, type=type, required=any(action.required for action in actions))
+
+    @classmethod
+    def from_append_actions(cls, *actions: _AppendAction) -> Self:
+        typing_imports: list[str] = []
+
+        types = [cls._get_type(action.type) for action in actions]
+        if "Any" in types:
+            typing_imports.append("Any")
+
+        type = f"list[{' | '.join(types)}]"
+
+        return cls(typin_imports=typing_imports, type=type, required=any(action.required for action in actions))
+
+
+def _is_literal(const: Any) -> TypeGuard[str | bytes | int | bool | None]:
+    # TODO Support for Enums
+    return isinstance(const, (str, int, bool, NoneType)) or (isinstance(const, bytes) and const.isascii())

--- a/src/django_autotyping/stubbing/django_context/_url_utils.py
+++ b/src/django_autotyping/stubbing/django_context/_url_utils.py
@@ -4,15 +4,7 @@ import hashlib
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
 
-from django.apps.registry import Apps
-from django.conf import LazySettings
-from django.db.models import NOT_PROVIDED, DateField, Field
-from django.urls import URLPattern, URLResolver, get_resolver
-from libcst.codemod.visitors import ImportItem
-
-from django_autotyping.typing import ModelType
-
-from .codemods._utils import to_pascal
+from django.urls import URLPattern, URLResolver
 
 
 @dataclass(eq=True, frozen=True)
@@ -105,73 +97,7 @@ class PathInfo:
         return " | ".join(tuples_str)
 
 
-class DjangoStubbingContext:
-    def __init__(self, apps: Apps, settings: LazySettings) -> None:
-        self.apps = apps
-        self.settings = settings
-
-    @staticmethod
-    def _get_model_alias(model: ModelType) -> str:
-        """Return an alias of the model, by converting the app label to PascalCase and joining
-        the app label to the model name.
-        """
-        app_label = to_pascal(model._meta.app_label)
-        return f"{app_label}{model.__name__}"
-
-    @property
-    def models(self) -> list[ModelType]:
-        """All the defined models."""
-        return self.apps.get_models()
-
-    @property
-    def model_imports(self) -> list[ImportItem]:
-        """A list of `ImportItem` instances.
-
-        Can be used to easily import all models in a stub file.
-        """
-
-        return [
-            ImportItem(
-                module_name=model._meta.app_config.models_module.__name__,
-                obj_name=model.__name__,
-                alias=self._get_model_alias(model) if self.is_duplicate(model) else None,
-            )
-            for model in self.models
-        ]
-
-    @property
-    def viewnames_lookups(self) -> defaultdict[str, PathInfo]:
-        """A mapping between viewnames to be used with `reverse` and the available lookup arguments."""
-        return _get_paths_infos(get_resolver())
-
-    def is_duplicate(self, model: ModelType) -> bool:
-        """Whether the model has a duplicate name with another model in a different app."""
-        return len([m for m in self.models if m.__name__ == model.__name__]) >= 2  # noqa: PLR2004
-
-    def get_model_name(self, model: ModelType) -> str:
-        """Return the name of the model in the context of a stub file.
-
-        If the model has a duplicate name, an alias is returned.
-        """
-        return self._get_model_alias(model) if self.is_duplicate(model) else model.__name__
-
-    def get_field_nullability(self, field: Field) -> bool:
-        """Determine if a field requires a value to be provided when instantiating a model.
-
-        In practice, there isn't any reliable way to determine this (even if Django does not provide
-        a default, things could be set at the database level). However, we can make some assumptions
-        regarding the field instance, see https://forum.djangoproject.com/t/26357 for more details.
-        """
-        # TODO use the same logic as the mypy plugin
-        return (
-            field.null
-            or field.has_default()
-            or getattr(field, "db_default", NOT_PROVIDED) is not NOT_PROVIDED  # No `has_db_default` method :/
-            or (isinstance(field, DateField) and (field.auto_now or field.auto_now_add))
-        )
-
-
-def _get_paths_infos(
+def get_paths_infos(
     url_resolver: URLResolver,
     parent_namespaces: list[str] | None = None,
 ) -> defaultdict[str, PathInfo]:
@@ -198,5 +124,5 @@ def _get_paths_infos(
             if pattern.namespace:
                 new_parent_namespaces.append(pattern.namespace)
 
-            paths_info = defaultdict(PathInfo, **paths_info, **_get_paths_infos(pattern, new_parent_namespaces))
+            paths_info = defaultdict(PathInfo, **paths_info, **get_paths_infos(pattern, new_parent_namespaces))
     return paths_info

--- a/src/django_autotyping/stubbing/django_context/django_context.py
+++ b/src/django_autotyping/stubbing/django_context/django_context.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from django.apps.registry import Apps
+from django.conf import LazySettings
+from django.db.models import NOT_PROVIDED, DateField, Field
+from django.urls import get_resolver
+from libcst.codemod.visitors import ImportItem
+
+from django_autotyping.typing import ModelType
+
+from ..codemods._utils import to_pascal
+from ._management_utils import ManagementCommand
+from ._url_utils import PathInfo, get_paths_infos
+
+
+class DjangoStubbingContext:
+    def __init__(self, apps: Apps, settings: LazySettings) -> None:
+        self.apps = apps
+        self.settings = settings
+
+    @staticmethod
+    def _get_model_alias(model: ModelType) -> str:
+        """Return an alias of the model, by converting the app label to PascalCase and joining
+        the app label to the model name.
+        """
+        app_label = to_pascal(model._meta.app_label)
+        return f"{app_label}{model.__name__}"
+
+    @property
+    def models(self) -> list[ModelType]:
+        """All the defined models."""
+        return self.apps.get_models()
+
+    @property
+    def model_imports(self) -> list[ImportItem]:
+        """A list of `ImportItem` instances.
+
+        Can be used to easily import all models in a stub file.
+        """
+
+        return [
+            ImportItem(
+                module_name=model._meta.app_config.models_module.__name__,
+                obj_name=model.__name__,
+                alias=self._get_model_alias(model) if self.is_duplicate(model) else None,
+            )
+            for model in self.models
+        ]
+
+    @property
+    def viewnames_lookups(self) -> defaultdict[str, PathInfo]:
+        """A mapping between viewnames to be used with `reverse` and the available lookup arguments."""
+        return get_paths_infos(get_resolver())
+
+    @property
+    def management_commands(self) -> dict[str, ManagementCommand]:
+        ...
+
+    def is_duplicate(self, model: ModelType) -> bool:
+        """Whether the model has a duplicate name with another model in a different app."""
+        return len([m for m in self.models if m.__name__ == model.__name__]) >= 2  # noqa: PLR2004
+
+    def get_model_name(self, model: ModelType) -> str:
+        """Return the name of the model in the context of a stub file.
+
+        If the model has a duplicate name, an alias is returned.
+        """
+        return self._get_model_alias(model) if self.is_duplicate(model) else model.__name__
+
+    def get_field_nullability(self, field: Field) -> bool:
+        """Determine if a field requires a value to be provided when instantiating a model.
+
+        In practice, there isn't any reliable way to determine this (even if Django does not provide
+        a default, things could be set at the database level). However, we can make some assumptions
+        regarding the field instance, see https://forum.djangoproject.com/t/26357 for more details.
+        """
+        # TODO use the same logic as the mypy plugin
+        return (
+            field.null
+            or field.has_default()
+            or getattr(field, "db_default", NOT_PROVIDED) is not NOT_PROVIDED  # No `has_db_default` method :/
+            or (isinstance(field, DateField) and (field.auto_now or field.auto_now_add))
+        )

--- a/src/django_autotyping/stubbing/django_context/django_context.py
+++ b/src/django_autotyping/stubbing/django_context/django_context.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from django.apps.registry import Apps
 from django.conf import LazySettings
+from django.core.management import get_commands
 from django.db.models import NOT_PROVIDED, DateField, Field
 from django.urls import get_resolver
 from libcst.codemod.visitors import ImportItem
@@ -11,7 +12,7 @@ from libcst.codemod.visitors import ImportItem
 from django_autotyping.typing import ModelType
 
 from ..codemods._utils import to_pascal
-from ._management_utils import ManagementCommand
+from ._management_utils import CommandInfo, get_commands_infos
 from ._url_utils import PathInfo, get_paths_infos
 
 
@@ -55,8 +56,8 @@ class DjangoStubbingContext:
         return get_paths_infos(get_resolver())
 
     @property
-    def management_commands(self) -> dict[str, ManagementCommand]:
-        ...
+    def management_commands_info(self) -> dict[str, CommandInfo]:
+        return get_commands_infos(get_commands())
 
     def is_duplicate(self, model: ModelType) -> bool:
         """Whether the model has a duplicate name with another model in a different app."""


### PR DESCRIPTION
Part of #44.

The rule is still incomplete, so it's disabled for now.